### PR TITLE
Require maven package due to old xmvn in COPR

### DIFF
--- a/ovirt-jboss-modules-maven-plugin.spec.in
+++ b/ovirt-jboss-modules-maven-plugin.spec.in
@@ -27,6 +27,9 @@ BuildRequires:	mvn(org.apache.maven.plugins:maven-source-plugin)
 BuildRequires:	mvn(org.codehaus.plexus:plexus-archiver)
 BuildRequires:	mvn(org.codehaus.plexus:plexus-utils)
 
+# Required because of old xmvn version in COPR
+BuildRequires: maven
+
 Requires:	java-11-openjdk-headless >= 1:11.0.0
 Requires:	javapackages-filesystem
 Requires:	plexus-archiver


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
