### PR TITLE
Maven Central update

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 .PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
-	dnf -y install git gzip java-11-openjdk-devel maven rpm-build sed
+	dnf -y install git gzip java-21-openjdk-devel maven rpm-build sed
 
 git_cfg_safe:
 	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "ovirt-jboss-modules-maven-plugin",
+    "mounts": [
+        "source=${localEnv:HOME}/.m2,target=/root/.m2,type=bind,consistency=cached"
+    ],
+    "remoteUser": "root",
+    "image": "mcr.microsoft.com/devcontainers/java:21",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none",
+            "installMaven": "true",
+            "mavenVersion": "3.9.6",
+            "installGradle": "true"
+        }
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: centos-stream-8
-            shortcut: cs8
-            container-name: el8stream
           - name: centos-stream-9
             shortcut: cs9
             container-name: el9stream
+          - name: centos-stream-10
+            shortcut: cs10
+            container-name: el10stream
 
     name: ${{ matrix.name }}
 
@@ -34,7 +34,7 @@ jobs:
       uses: ovirt/checkout-action@main
 
     - name: Use cache for maven
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ To submit a bug or suggest an enhancement for oVirt JBoss Modules Maven Plugin p
 
 If you have any other questions or suggestions, you can join and contact us on the [oVirt Users forum / mailing list](https://lists.ovirt.org/admin/lists/users.ovirt.org/).
 
+## Release to Maven Central
+
+To deploy a new release to [Maven Central](https://central.sonatype.com/artifact/org.ovirt.maven.plugins/ovirt-jboss-modules-maven-plugin), bump the release version in the `pom.xml` run the following command:
+
+```bash
+mvn deploy -Psign
+```
+After this command has succesfully run, the next step is to manually deploy this release on the maven central website itself.

--- a/ovirt-jboss-modules-maven-plugin.spec.in
+++ b/ovirt-jboss-modules-maven-plugin.spec.in
@@ -12,15 +12,9 @@ License:	ASL 2.0
 URL:		https://www.ovirt.org
 Source:		%{name}-%{version}.tar.gz
 
-# We need to disable automatic generation of "Requires: java-headless >= 1:11"
-# by xmvn, becase JDK 11 doesn't provide java-headless artifact, but it
-# provides java-11-headless.
-AutoReq:	no
-
 BuildArch:	noarch
 
-BuildRequires:  java-11-openjdk-devel
-BuildRequires:	maven-local
+BuildRequires:	maven-local-openjdk21
 BuildRequires:  mvn(org.apache.maven.plugins:maven-compiler-plugin)
 BuildRequires:	mvn(org.apache.maven.plugins:maven-plugin-plugin)
 BuildRequires:	mvn(org.apache.maven.plugins:maven-source-plugin)
@@ -30,11 +24,7 @@ BuildRequires:	mvn(org.codehaus.plexus:plexus-utils)
 # Required because of old xmvn version in COPR
 BuildRequires: maven
 
-Requires:	java-11-openjdk-headless >= 1:11.0.0
-Requires:	javapackages-filesystem
-Requires:	plexus-archiver
-Requires:	plexus-utils
-
+Requires: (java-11-openjdk-headless or java-21-openjdk-headless)
 
 %description
 Maven Plugin used to generate and attach an artifact containing
@@ -53,8 +43,6 @@ This package contains the API documentation for %{name}.
 %pom_remove_plugin :maven-javadoc-plugin pom.xml
 
 %build
-# Necessary to override the default for xmvn, which is JDK 8
-export JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
 
 %mvn_build
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,17 @@
   </scm>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <javadoc.source>11</javadoc.source>
-    <maven.version>3.5.4</maven.version>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.version>3.9.6</maven.version>
+    <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
+    <plexus-archiver.version>3.6.0</plexus-archiver.version>
+    <plexus-utils.version>3.1.0</plexus-utils.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
   </properties>
 
   <dependencies>
@@ -85,20 +91,20 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.6.0</version>
+      <version>${maven-plugin-annotations.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>3.6.0</version>
+      <version>${plexus-archiver.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.1.0</version>
+      <version>${plexus-utils.version}</version>
     </dependency>
 
   </dependencies>
@@ -108,17 +114,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
+          <release>${maven.compiler.release}</release>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${maven-plugin-plugin.version}</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>
@@ -141,7 +146,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>${maven-source-plugin.version}</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -155,10 +160,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>${maven-javadoc-plugin.version}</version>
         <configuration>
             <excludePackageNames>*.internal.*</excludePackageNames>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <doclint>none</doclint>
         </configuration>
         <executions>
           <execution>
@@ -180,6 +185,16 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>${central-publishing-maven-plugin.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>
@@ -193,7 +208,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>${maven-gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -209,16 +224,5 @@
     </profile>
 
   </profiles>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-  </distributionManagement>
 
 </project>


### PR DESCRIPTION
* updated dependencies to deploy to maven central
* cleanup pom
* implementation of developer container to run builds in containerized environments
* added centos10 support, dropped centos8
* use java21 instead of 11 to build but still release for 11.